### PR TITLE
Patch "Repository not found" error

### DIFF
--- a/src/Environment.js
+++ b/src/Environment.js
@@ -175,6 +175,7 @@ export function createEnvironment(
   preloadCache: ?PreloadCache,
 ) {
   const store = new Store(recordSource);
+  store.holdGC();
   let environment;
   const getEnvironment = () => environment;
   environment = new Environment({


### PR DESCRIPTION
Disables GC so that the store is not cleared when the logged-in query is run.

The "Repository not found" error happens because Relay GCs the data for the preloaded query before it has a chance to render. Still trying to work out why that happens, but this should stop it for now.