### PR TITLE
Better scroll handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@tippy.js/react": "^2.2.2",
     "date-fns": "2.9.0",
+    "detect-passive-events": "^1.0.5",
     "email-reply-parser": "^1.2.1",
     "feed": "^4.0.0",
     "gif-stream": "^1.1.0",

--- a/src/Posts.js
+++ b/src/Posts.js
@@ -9,6 +9,7 @@ import {Box} from 'grommet/components/Box';
 import {Heading} from 'grommet/components/Heading';
 import Link from 'next/link';
 import nullthrows from 'fbjs/lib/nullthrows';
+import detectPassiveEvents from 'detect-passive-events';
 
 type Props = {|
   relay: RelayPaginationProp,
@@ -30,7 +31,7 @@ const Posts = ({relay, repository}: Props) => {
         ) {
           if (!isLoading && !relay.isLoading() && relay.hasMore()) {
             setIsLoading(true);
-            relay.loadMore(10, x => {
+            relay.loadMore(60, x => {
               setIsLoading(false);
             });
           }
@@ -39,7 +40,11 @@ const Posts = ({relay, repository}: Props) => {
     }
   }, [relay, isLoading, setIsLoading]);
   React.useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener(
+      'scroll',
+      handleScroll,
+      detectPassiveEvents.hasSupport ? {passive: true, capture: false} : false,
+    );
     return () => {
       window.removeEventListener('scroll', handleScroll);
     };

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -13,12 +13,82 @@ import {Grommet} from 'grommet/components/Grommet';
 import theme from '../lib/theme';
 import Head from '../Head';
 import ErrorBoundary from '../ErrorBoundary';
+import {useRouter} from 'next/router';
+
+function AppComponent({
+  Component,
+  pageProps,
+  indexPageMemo,
+  indexPageScrollPos,
+  loginStatus,
+  isIndexPage,
+}: any) {
+  React.useEffect(() => {
+    if (isIndexPage && indexPageScrollPos.current) {
+      window.scrollTo(0, indexPageScrollPos.current);
+    }
+  }, [isIndexPage]);
+
+  let page;
+  if (!isIndexPage || !indexPageMemo.current) {
+    const res = (
+      <div style={{position: 'relative'}}>
+        <ErrorBoundary>
+          <React.Suspense fallback={null}>
+            <Component
+              key={loginStatus === 'logged-in' ? 'logged-in' : 'logged-out'}
+              {...pageProps}
+            />
+          </React.Suspense>
+        </ErrorBoundary>
+      </div>
+    );
+    if (isIndexPage) {
+      indexPageMemo.current = res;
+    } else {
+      page = res;
+    }
+  }
+
+  // Keep the index page rendered so that we don't lose any posts we loaded
+  return (
+    <>
+      <div style={{display: isIndexPage ? 'block' : 'none'}}>
+        {indexPageMemo.current}
+      </div>
+      {page}
+    </>
+  );
+}
 
 function App({Component, pageProps}: any) {
+  const router = useRouter();
+
+  const indexPageMemo = React.useRef();
+  // Stores scroll position of the index page for better back behavior
+  // Ideally we would assign the scroll pos to the history item in the stack,
+  // but that doesn't appear possible with next.js
+  const indexPageScrollPos = React.useRef();
+
   const [loginStatus, setLoginStatus] = React.useReducer(
     (_state, newState) => newState,
     'checking',
   );
+
+  const isIndexPage = router.pathname === '/';
+
+  const handleRouteChangeStart = (x, y, z) => {
+    if (isIndexPage) {
+      indexPageScrollPos.current = window.scrollY;
+    }
+  };
+
+  React.useEffect(() => {
+    router.events.on('routeChangeStart', handleRouteChangeStart);
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart);
+    };
+  }, [isIndexPage]);
 
   const notificationContext = React.useContext(NotificationContext);
 
@@ -63,16 +133,14 @@ function App({Component, pageProps}: any) {
           login,
           logout,
         }}>
-        <div style={{position: 'relative'}}>
-          <ErrorBoundary>
-            <React.Suspense fallback={null}>
-              <Component
-                key={loginStatus === 'logged-in' ? 'logged-in' : 'logged-out'}
-                {...pageProps}
-              />
-            </React.Suspense>
-          </ErrorBoundary>
-        </div>
+        <AppComponent
+          Component={Component}
+          pageProps={pageProps}
+          indexPageMemo={indexPageMemo}
+          indexPageScrollPos={indexPageScrollPos}
+          loginStatus={loginStatus}
+          isIndexPage={isIndexPage}
+        />
       </UserContext.Provider>
     </RelayEnvironmentProvider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4914,6 +4914,11 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
+detect-passive-events@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/detect-passive-events/-/detect-passive-events-1.0.5.tgz#ce324db665123bef9e368b8059ff95d95217cc05"
+  integrity sha512-foW7Q35wwOCxVzW0xLf5XeB5Fhe7oyRgvkBYdiP9IWgLMzjqUqTvsJv9ymuEWGjY6AoDXD3OC294+Z9iuOw0QA==
+
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"


### PR DESCRIPTION
The main change here is to keep the index page mounted in the dom when you navigate to a blog post. That lets us restore your scroll position when you navigate back to the index page.

A couple of minor changes:
1. Fetches 60 new posts instead of only 10 new posts per page
2. Uses a [passive scroll listener](https://web.dev/uses-passive-event-listeners/?utm_source=lighthouse&utm_medium=unknown), which lets the browser do some optimizations 