### PR TITLE
Fix highlighting for large-ish code blocks

### DIFF
--- a/src/lib/codeHighlight.js
+++ b/src/lib/codeHighlight.js
@@ -66,8 +66,10 @@ export function fetchTokenInfo({
           },
           body: JSON.stringify({
             code,
-            language: language,
-            theme: Config.codeTheme,
+            settings: {
+              language: language,
+              theme: Config.codeTheme,
+            },
           }),
         });
   return resp


### PR DESCRIPTION
Fixes a bug in how the settings for the highlighting were provided to sourcecodeshots.