### PR TITLE
Adds support for markdown footnotes and linking to headings

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,10 +1,4 @@
-FROM node:10-alpine as builder
-
-RUN npm install -g yarn
-
-ENV HOST 0.0.0.0
-ENV RAZZLE_PUBLIC_DIR build/public
-ENV PORT 8080
+FROM node:14 as builder
 
 COPY package.json .
 COPY yarn.lock .
@@ -14,31 +8,30 @@ RUN yarn install
 
 COPY . .
 
-RUN yarn razzle build
+ENV NODE_ENV=production
+
+RUN yarn build && rm -rf .next/cache
 
 # Make smaller prod image
-FROM node:10-alpine as node_installer
+FROM node:14 as node_installer
 
-RUN npm install -g yarn
-
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 COPY package.json .
 COPY yarn.lock .
 
 RUN yarn install --production
 
-FROM node:10-alpine
+FROM node:14
 
-ENV NODE_ENV production
-ENV HOST 0.0.0.0
-ENV RAZZLE_PUBLIC_DIR build/public
-ENV PORT 8080
+ENV NODE_ENV=production
 
 COPY package.json .
 COPY yarn.lock .
 COPY .env .
+COPY server.js.example server.js
+COPY next.config.js .
 
-COPY --from=builder build build
+COPY --from=builder .next .next
 COPY --from=node_installer node_modules node_modules
-CMD [ "node", "/build/server.js" ]
+CMD [ "node", "server.js" ]

--- a/next.config.js
+++ b/next.config.js
@@ -6,8 +6,8 @@ module.exports = () => {
       NEXT_PUBLIC_SITE_HOSTNAME:
         process.env.NEXT_PUBLIC_SITE_HOSTNAME ||
         process.env.RAZZLE_SITE_HOSTNAME ||
-        (process.env.VERCEL_URL ? 'https://' + process.env.VERCEL_URL : null) ||
         process.env.URL,
+      NEXT_PUBLIC_VERCEL_URL: process.env.VERCEL_URL,
       NEXT_PUBLIC_ONEGRAPH_APP_ID:
         process.env.NEXT_PUBLIC_ONEGRAPH_APP_ID ||
         process.env.RAZZLE_ONEGRAPH_APP_ID,

--- a/src/Post.js
+++ b/src/Post.js
@@ -577,7 +577,20 @@ export const Post = ({relay, post, context}: Props) => {
 
         <Box direction="row" justify="between"></Box>
         <Text>
-          <MarkdownRenderer trustedInput={true} source={post.body} />
+          <MarkdownRenderer
+            trustedInput={true}
+            source={post.body}
+            addHeadingIds={context === 'details'}
+            HashLink={function HashLink(props) {
+              return (
+                <Link
+                  href="/post/[...slug]"
+                  as={`${postPath({post})}${props.hash}`}>
+                  <a>{props.children}</a>
+                </Link>
+              );
+            }}
+          />
         </Text>
       </Box>
     </PostBox>

--- a/src/PostRoot.js
+++ b/src/PostRoot.js
@@ -28,12 +28,12 @@ export const query = graphql`
     $repoName: String!
     $repoOwner: String!
   )
-    @persistedQueryConfiguration(
-      accessToken: {environmentVariable: "OG_GITHUB_TOKEN"}
-      fixedVariables: {environmentVariable: "REPOSITORY_FIXED_VARIABLES"}
-      freeVariables: ["issueNumber"]
-      cacheSeconds: 300
-    ) {
+  @persistedQueryConfiguration(
+    accessToken: {environmentVariable: "OG_GITHUB_TOKEN"}
+    fixedVariables: {environmentVariable: "REPOSITORY_FIXED_VARIABLES"}
+    freeVariables: ["issueNumber"]
+    cacheSeconds: 300
+  ) {
     gitHub {
       viewer {
         login
@@ -114,7 +114,7 @@ export const PostRoot = ({issueNumber}: {issueNumber: number}) => {
     !gitHub ||
     !post ||
     !labels ||
-    !labels.find(l => l && l.name.toLowerCase() === 'publish')
+    !labels.find((l) => l && l.name.toLowerCase() === 'publish')
   ) {
     return <ErrorBox error={new Error('Missing post.')} />;
   } else {

--- a/src/Posts.js
+++ b/src/Posts.js
@@ -124,12 +124,12 @@ export default createPaginationContainer(
         $repoOwner: String!
         $repoName: String!
       )
-        @persistedQueryConfiguration(
-          accessToken: {environmentVariable: "OG_GITHUB_TOKEN"}
-          freeVariables: ["count", "cursor", "orderBy"]
-          fixedVariables: {environmentVariable: "REPOSITORY_FIXED_VARIABLES"}
-          cacheSeconds: 300
-        ) {
+      @persistedQueryConfiguration(
+        accessToken: {environmentVariable: "OG_GITHUB_TOKEN"}
+        freeVariables: ["count", "cursor", "orderBy"]
+        fixedVariables: {environmentVariable: "REPOSITORY_FIXED_VARIABLES"}
+        cacheSeconds: 300
+      ) {
         gitHub {
           repository(name: $repoName, owner: $repoOwner) {
             __typename

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react';
+// $FlowFixMe: Silence warning about no Html export
 import Document, {Html, Head, Main, NextScript} from 'next/document';
 import {ServerStyleSheet} from 'styled-components';
 import config from '../config';


### PR DESCRIPTION
To use footnotes in markdown, just do this:

```
Here's a simple footnote,[^1] and here's a longer one.[^bignote]

[^1]: This is the first footnote.

[^bignote]: Here's one with multiple paragraphs and code.

    Indent paragraphs to include them in the footnote.

    `{ my code }`

    Add as many paragraphs as you like.
```

In your last post, you'll want to make a change like:

```diff
- Notice that the wires carry a charge, but we choose to interpret _meaning_ in the charge. “high charge” means 1, and “low charge” means 0. Nothing changes in the machine, this is just something we decided as humans (1).
+ Notice that the wires carry a charge, but we choose to interpret _meaning_ in the charge. “high charge” means 1, and “low charge” means 0. Nothing changes in the machine, this is just something we decided as humans[^1].
...
- (1) I say this pretty lightly, but treating the charge on circuits as code was a pretty [phenomenal innovation](https://en.wikipedia.org/wiki/Claude_Shannon#Logic_circuits). I could only imagine what it might have been like, when Shannon showed a full-adder.
+ [^1]: I say this pretty lightly, but treating the charge on circuits as code was a pretty [phenomenal innovation](https://en.wikipedia.org/wiki/Claude_Shannon#Logic_circuits). I could only imagine what it might have been like, when Shannon showed a full-adder.

```

You can use whatever identifier you want (e.g. `1` or `bignote` above), but probably best to keep with numbered footnotes because it looks a bit nicer when you view it on GitHub.

This also adds support for linking directly to headlines. You would link to the `7: Simulate Enabler` headline like so:

```
This is a [link to simulate enabler](#7-simulate-enabler)
```
