### PR TITLE
Add retry if sourcecodeshots request fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@tippyjs/react": "4.1.0",
+    "@vercel/fetch-retry": "^5.0.3",
     "date-fns": "2.9.0",
     "email-reply-parser": "^1.2.1",
     "feed": "^4.0.0",
@@ -51,7 +52,11 @@
     "extends": "react-app"
   },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/src/MarkdownRenderer.js
+++ b/src/MarkdownRenderer.js
@@ -132,8 +132,8 @@ export class CodeBlock extends React.PureComponent<
         style={{
           display: 'block',
           overflowX: 'auto',
-          padding: '1em',
-          borderRadius: 4,
+          padding: '0.5em',
+          borderRadius: 5,
           color: defaultThemeColors[theme]?.foregroundColor || '#fff',
           background: defaultThemeColors[theme]?.backgroundColor || '#000',
         }}>

--- a/src/lib/codeHighlight.js
+++ b/src/lib/codeHighlight.js
@@ -1,6 +1,9 @@
 // @flow
 
 import parseMarkdown from './parseMarkdown';
+import setupFetch from '@vercel/fetch-retry';
+
+let fetch;
 
 type Tokens = Array<{
   text: string,
@@ -63,6 +66,7 @@ export function fetchTokenInfo({
   language: ?string,
   theme: string,
 }): TokenInfo | Promise<TokenInfo> {
+  fetch = fetch || setupFetch();
   const cacheKey = makeCacheKey({code, language, theme});
   const fromCache = TOKEN_INFO_CACHE.get(cacheKey);
   if (fromCache) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2233,6 +2233,14 @@
   dependencies:
     "@types/node" "*"
 
+"@vercel/fetch-retry@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@vercel/fetch-retry/-/fetch-retry-5.0.3.tgz#cce5d23f6e64f6f525c24e2ac7c78f65d6c5b1f4"
+  integrity sha512-DIIoBY92r+sQ6iHSf5WjKiYvkdsDIMPWKYATlE0KcUAj2RV6SZK9UWpUzBRKsofXqedOqpVjrI0IE6AWL7JRtg==
+  dependencies:
+    async-retry "^1.3.1"
+    debug "^3.1.0"
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -3018,6 +3026,13 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
+async-retry@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.1.tgz#139f31f8ddce50c0870b0ba558a6079684aaed55"
+  integrity sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==
+  dependencies:
+    retry "0.12.0"
 
 async@^1.5.2:
   version "1.5.2"
@@ -6269,7 +6284,7 @@ file-loader@^3.0.1:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
 
-file-uri-to-path@1:
+file-uri-to-path@1, file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
@@ -12242,7 +12257,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-retry@^0.12.0:
+retry@0.12.0, retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=


### PR DESCRIPTION
Adds retry to code highlighting requests. 

My hypothesis is that the vercel build machines are making more concurrent outbound requests than they can handle during the build. This will add retries to the code highlight requests to recover from those errors.

Not 100% sure this will fix the problem--the build succeeded before this change on my local machine.