### PR TITLE
Add horizontally-scrollable container to tables

### DIFF
--- a/src/MarkdownRenderer.js
+++ b/src/MarkdownRenderer.js
@@ -299,6 +299,14 @@ function headingSlug(props) {
   return slugify(text.toLowerCase());
 }
 
+function TableWrapper(props) {
+  return (
+    <div style={{overflowX: 'auto', overflowY: 'visible'}}>
+      <Table {...props} />
+    </div>
+  );
+}
+
 const defaultRenderers = ({
   isRss,
   addHeadingIds,
@@ -355,7 +363,7 @@ const defaultRenderers = ({
     linkReference(props) {
       return <span {...props} />;
     },
-    table: Table,
+    table: TableWrapper,
     tableHead: TableHeader,
     tableBody: TableBody,
     tableRow: TableRow,


### PR DESCRIPTION
Adds a scrollable container to tables. If the tables are too wide, they'll scroll horizontally.