### PR TITLE
Don't rerender if onegraph query fails

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -123,7 +123,6 @@ function App({Component, pageProps}: any) {
       })
       .catch((e) => {
         console.error('Error checking login status', e);
-        setLoginStatus('error');
       });
   }, [environment]);
 


### PR DESCRIPTION
This will make things work a bit better in Cuba. You shouldn't get the flash of content that disappears anymore.