### PR TITLE
Fallback on error

### DIFF
--- a/scripts/persistQuery.js
+++ b/scripts/persistQuery.js
@@ -34,6 +34,7 @@ const PERSIST_QUERY_MUTATION = `
     $query: String!
     $fixedVariables: JSON
     $cacheStrategy: OneGraphPersistedQueryCacheStrategyArg
+    $fallbackOnError: Boolean!
   ) {
     oneGraph {
       createPersistedQuery(
@@ -44,6 +45,7 @@ const PERSIST_QUERY_MUTATION = `
           cacheStrategy: $cacheStrategy
           freeVariables: $freeVariables
           fixedVariables: $fixedVariables
+          fallbackOnError: $fallbackOnError
         }
       ) {
         persistedQuery {
@@ -162,6 +164,7 @@ async function persistQuery(queryText) {
           timeToLiveSeconds: cacheSeconds,
         }
       : null,
+    fallbackOnError: cacheSeconds ? true : false,
   };
 
   const body = JSON.stringify({


### PR DESCRIPTION
Sets a flag when we persist the query that will cause OneGraph to fallback to the last successful response In case a persisted query returns an error.

This will prevent any rate-limit errors from taking down the blog.

A bit on how it works, if you're interested:

When a query is persisted with `fallbackOnError` set to true and the query executes successfully , then OneGraph will store the result in a google storage bucket. The bucket is set to auto-delete items after 30 days. If the persisted query executes later with an error in the `errors` field, then OneGraph will fetch the result of the successful execution from storage and return that instead.

We add a little bit of data to the `extensions` field so that you can tell if the fallback was used and why. The result looks something like this:

```json
{
  "data": {
    "npm": {
      "package": {
        "name": "relay",
        "id": "relay",
        "distTags": {
          "latest": {
            "versionString": "0.8.0-1"
          }
        }
      }
    }
  },
  "extensions": {
    "persistedQueryFallback": true,
    "lastModified": "2021-06-15T02:29:28-00:00",
    "errors": [
      {
        "message": "Whoops!",
        "path": [
          "npm",
          "package"
        ]
      }
    ]
  }
}
```